### PR TITLE
doc: Improve monospace font stack on macOS

### DIFF
--- a/doc/css/custom.less
+++ b/doc/css/custom.less
@@ -70,7 +70,7 @@ h2 {
 
 pre, code, kbd, samp, tt {
   // font-family: Cousine, "Liberation Mono", "Courier New", monospace;
-  font-family: "Liberation Mono", "Courier New", monospace;
+  font-family: "Liberation Mono", Menlo, Monaco, "Courier New", monospace;
   .font-size(12);
   background-color: #F8F8F8;
 }


### PR DESCRIPTION
Hello. macOS does not come with `Liberation Mono` installed thus the current documentation's monospace font stack falls back to `Courier New`. As you can see in the screenshot below it looks _extremely_ thin. I thought I'd try to add a couple better options using only fonts installed by default on this platform.

Courier New
---

This is the present:

![screen shot 2017-08-27 at 17 20 55](https://user-images.githubusercontent.com/2104122/29751354-8cd2d9f6-8b4c-11e7-893b-c7545a891607.png)

Menlo
---

This has been the default for the Apple's shell program `Terminal.app` for a while now. Incidentally https://play.golang.org uses it too.

![screen shot 2017-08-27 at 17 20 59](https://user-images.githubusercontent.com/2104122/29751359-9947464a-8b4c-11e7-9eda-55691c221db5.png)

Monaco
---

This is the font that macs used to use before `Menlo` was a thing. Older mostly unsupported Macs will have nice readable text too 😄 

![screen shot 2017-08-27 at 17 36 56](https://user-images.githubusercontent.com/2104122/29751510-a87d637c-8b4e-11e7-9620-9e763f25d09c.png)

Courier
---

Looking at how `Courier` renders one would be tempted to use it. Problem is the situation is quite the opposite on other platforms (e.g. Linux) where `Courier New` renders much better on average. Hence even if this works well on mac I decided not to include it.

![screen shot 2017-08-27 at 17 21 02](https://user-images.githubusercontent.com/2104122/29751392-0cc7ee44-8b4d-11e7-86ac-c5fea2793c10.png)

Thanks for taking the time to look through this.
